### PR TITLE
Fixed comment colors

### DIFF
--- a/VSThemeProject/Nordic.vstheme
+++ b/VSThemeProject/Nordic.vstheme
@@ -8798,10 +8798,10 @@
       </Color>
       <Color Name="CodeReviewDiscussionItemSelected">
         <Background Type="CT_RAW" Source="FFECEFF4" />
-        <Foreground Type="CT_RAW" Source="FFECEFF4" />
+        <Foreground Type="CT_RAW" Source="FF2E3440" />
       </Color>
       <Color Name="CodeReviewDiscussionSelectedActionLink">
-        <Background Type="CT_RAW" Source="FFECEFF4" />
+        <Background Type="CT_RAW" Source="FF5E81AC" />
       </Color>
       <Color Name="TextBoxHintText">
         <Background Type="CT_RAW" Source="FF646E81" />
@@ -8883,7 +8883,7 @@
         <Foreground Type="CT_RAW" Source="FFECEFF4" />
       </Color>
       <Color Name="CodeReviewDiscussionDisabledActionLink">
-        <Background Type="CT_RAW" Source="FFD8DEE9" />
+        <Background Type="CT_RAW" Source="FF4C566A" />
       </Color>
       <Color Name="TeamExplorerHomeDefaultIconFill">
         <Background Type="CT_RAW" Source="FF5E81AC" />


### PR DESCRIPTION
"Code Review" comments in the TeamExplorer were unreadable when selected.

To fix that issue, the Foreground color for the `CodeReviewDiscussionItemSelected` entry and the Background color for the `CodeReviewDiscussionSelectedActionLink` entry needed to be changed to make the text visible, even when the comment is selected. I also darkened the `CodeReviewDiscussionDisabledActionLink` text color to make it stand out more on the bright background.

Here's a before:
![nordic_before](https://user-images.githubusercontent.com/27204033/168796228-91f8f00a-b466-4a0d-9329-f24d6074af81.png)

And the after (sorry for the censored text):
![nordic_after](https://user-images.githubusercontent.com/27204033/168796239-326df350-7e09-438c-827c-ab308b0c08a1.png)