### PR TITLE
Updated CR comment colors to better match the theme

### DIFF
--- a/VSThemeProject/Nordic.vstheme
+++ b/VSThemeProject/Nordic.vstheme
@@ -8797,11 +8797,11 @@
         <Background Type="CT_RAW" Source="FF3B4252" />
       </Color>
       <Color Name="CodeReviewDiscussionItemSelected">
-        <Background Type="CT_RAW" Source="FFECEFF4" />
-        <Foreground Type="CT_RAW" Source="FF2E3440" />
+        <Background Type="CT_RAW" Source="FF434C5E" />
+        <Foreground Type="CT_RAW" Source="FFECEFF4" />
       </Color>
       <Color Name="CodeReviewDiscussionSelectedActionLink">
-        <Background Type="CT_RAW" Source="FF5E81AC" />
+        <Background Type="CT_RAW" Source="FF434C5E" />
       </Color>
       <Color Name="TextBoxHintText">
         <Background Type="CT_RAW" Source="FF646E81" />
@@ -8883,7 +8883,7 @@
         <Foreground Type="CT_RAW" Source="FFECEFF4" />
       </Color>
       <Color Name="CodeReviewDiscussionDisabledActionLink">
-        <Background Type="CT_RAW" Source="FF4C566A" />
+        <Background Type="CT_RAW" Source="FFD8DEE9" />
       </Color>
       <Color Name="TeamExplorerHomeDefaultIconFill">
         <Background Type="CT_RAW" Source="FF5E81AC" />


### PR DESCRIPTION
Updated code review comment colors to better match the theme.

<table>
    <tr>
        <th>Before</th>
        <th>Before (selected)</th>
        <th>After (selected)</th>
    </tr>
    <tr>
        <td>
            <img height="400px" src="https://user-images.githubusercontent.com/27204033/169747829-d2b192a9-90da-49cd-8ca9-a98e225b0ed0.png"/>
        </td>
        <td>
            <img height="400px" src="https://user-images.githubusercontent.com/27204033/169750895-cf2b0c47-0129-4a84-96bf-51a7ce548aba.png"/> 
        </td>
        <td>
            <img height="400px" src="https://user-images.githubusercontent.com/27204033/169750493-26fc35c5-85b6-499a-8fe9-fd8a8c2fc093.png"/>
        </td>
    </tr>
</table>



